### PR TITLE
Updated for >3.2.1 + new playbook

### DIFF
--- a/roles/monitoring_agent/files/telegraf_checks/logs_data.py
+++ b/roles/monitoring_agent/files/telegraf_checks/logs_data.py
@@ -17,13 +17,16 @@ def parse_logs():
 
     for line in Pygtail("/var/log/syslog"):
         # print line
-        if "sent to neighbor" in line:
-            reason = line.split('(')[1].split(')')[0]
-        if "Down BGP Notification" in line:
+        #if "sent to neighbor" in line:
+            #reason = line.split('(')[1].split(')')[0]
+        if "%ADJCHANGE: neighbor" in line:
             # print "***found*** " + '"'+str(line.split(' ')[5])+'"'
-            peer = line.split(' ')[5]
+            msg = line.split()
+            peer = msg[5]
+            status = msg[9]
+            reason = msg[-2]+" "+msg[-1]
         if len(reason) > 0 and len(peer) > 0:
-            data.add_row({"msg":"log"},{"reason":'"'+reason+" on "+gethostname()+" from "+peer+'"',"peer":'"'+peer+'"'})
+            data.add_row({"msg":"log"},{"reason":'"BGP Neighbor '+status+": "+reason+" on "+gethostname()+" from "+peer+'"',"peer":'"'+peer+'"'})
             reason = ""
             peer = ""
 

--- a/update-scripts.yml
+++ b/update-scripts.yml
@@ -1,0 +1,18 @@
+- hosts: leafs spines
+  become: yes
+  tasks:
+    - name: Copy scripts for checks
+      copy: src=roles/monitoring_agent/files/telegraf_checks/{{ item.script }} dest=/etc/telegraf/checks/
+      with_items:
+        - { script: "bgp_neighbor_data.py" }
+        - { script: "hwenv_data.py" }
+        - { script: "interface_data.py" }
+        - { script: "lldp_data.py" }
+        - { script: "output_module.py" }
+        - { script: "sysenv_data.py" }
+        - { script: "logs_data.py" }
+      register: scripts
+    
+    - name: Restart telegraph on switches
+      service: name=telegraf state=restarted
+      when: scripts.changed


### PR DESCRIPTION
Updated the Pygtail identification of a new BGP log for the current format used by Cumulus Quagga in versions 3.2.1 and higher. Added a new playbook to push only telegraf file updates to switches and restart the service.
